### PR TITLE
Add support for GCC 4.4. This allows building on RHEL 6.

### DIFF
--- a/buildSrc/linux.gradle
+++ b/buildSrc/linux.gradle
@@ -57,7 +57,7 @@ def ccFlags = [
         IS_DEBUG_NATIVE ? ["-ggdb", "-DVERBOSE"] : ["-O2", "-DNDEBUG"]].flatten()
 def ccFlagsGTK3 = ccFlags
 //ccFlags.addAll(["-Wnon-virtual-dtor", "-Woverloaded-virtual", "-std=c++0x"])
-def linkFlags = ["-static-libgcc", "-static-libstdc++", "-shared", commonFlags,
+def linkFlags = ["-static-libgcc", "-Bstatic", "-lstdc++", "-Bdynamic", "-shared", commonFlags,
                  "-z", "relro",
                  "-Wl,--gc-sections"].flatten()
 def defaultLinkFlags = linkFlags.flatten()
@@ -267,7 +267,7 @@ LINUX.launcherlibrary.compiler = compiler
 LINUX.launcherlibrary.ccFlags = ["-fstack-protector", "-DJAVAARCH=\"$OS_ARCH\"", "-I$JDK_HOME/include", "-I$JDK_HOME/include/linux", "-c", "-fPIC",
 "-std=gnu++98", "-ffunction-sections", "-fdata-sections"]
 LINUX.launcherlibrary.linker = linker
-LINUX.launcherlibrary.linkFlags = ["-z", "relro", "-ldl", "-lpthread", "-shared", "-static-libgcc", "-static-libstdc++", "-Wl,--gc-sections"]
+LINUX.launcherlibrary.linkFlags = ["-z", "relro", "-ldl", "-lpthread", "-shared", "-static-libgcc", "-Bstatic", "-lstdc++", "-Bdynamic", "-Wl,--gc-sections"]
 if (!IS_64) {
     LINUX.launcherlibrary.ccFlags += "-m32"
     LINUX.launcherlibrary.linkFlags += "-m32"

--- a/modules/graphics/src/main/native-glass/gtk/GlassApplication.cpp
+++ b/modules/graphics/src/main/native-glass/gtk/GlassApplication.cpp
@@ -64,8 +64,9 @@ static gboolean call_runnable (gpointer data)
 
 extern "C" {
 
-
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
 #pragma GCC diagnostic push
+#endif  // __GNUC__
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 static void init_threads() {
     gboolean is_g_thread_get_initialized = FALSE;
@@ -79,7 +80,9 @@ static void init_threads() {
     }
     gdk_threads_init();
 }
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
 #pragma GCC diagnostic pop
+#endif  // __GNUC__
 
 jboolean gtk_verbose = JNI_FALSE;
 


### PR DESCRIPTION
GCC 4.4 does not support `-static-libstdc++`, so this is replaced with `-Bstatic -lstdc++ -Bdynamic` which does the same.
Support for pragma diagnostic push and pop also requires a newer GCC, fix based on: https://github.com/protocolbuffers/protobuf/issues/4156

These changes allow me to build and run JavaFX applications with the provided OpenJDK on a RHEL6 system.
I saw that OpenJFX is included in the Windows builds. Could you consider including it in the builds you do on CentOS 6 as well?